### PR TITLE
Merchant items show page

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -7,4 +7,21 @@ class Merchants::ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    item = Item.find(params[:id])
+    if item.update(item_params)
+      redirect_to "/merchants/#{item.merchant_id}/items/#{item.id}"
+      flash[:success] = "Information Successfully Updated"
+    end
+  end
+
+  private
+  def item_params
+    params.permit(:name, :description, :unit_price)
+  end
 end

--- a/app/views/merchants/items/edit.html.erb
+++ b/app/views/merchants/items/edit.html.erb
@@ -1,0 +1,12 @@
+<%= form_with url: "/merchants/#{@item.merchant_id}/items/#{@item.id}", method: :patch, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name, value: @item.name %>
+
+  <%= form.label :description %>
+  <%= form.text_field :description, value: @item.description %>
+
+  <%= form.label :unit_price %>
+  <%= form.number_field :unit_price, value: @item.unit_price %>
+
+  <%= form.submit %>
+<% end %>

--- a/app/views/merchants/items/show.html.erb
+++ b/app/views/merchants/items/show.html.erb
@@ -4,3 +4,7 @@
 
 <%= link_to "Update Item Information",
     "/merchants/#{@item.merchant_id}/items/#{@item.id}/edit" %>
+
+<% flash.each do |type, message| %>
+  <p><%= message %></p>
+<% end %>

--- a/app/views/merchants/items/show.html.erb
+++ b/app/views/merchants/items/show.html.erb
@@ -1,3 +1,6 @@
 <h1><%= @item.name %></h1>
 <h3>Description: <%= @item.description %></h3>
 <h3>Current Selling Price: $<%= @item.unit_price_to_currency %></h3>
+
+<%= link_to "Update Item Information",
+    "/merchants/#{@item.merchant_id}/items/#{@item.id}/edit" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   namespace :merchants do
     get '/:id/items', to: 'items#index'
     get '/:id/items/:id', to: 'items#show'
+    get '/:id/items/:id/edit', to: 'items#edit'
+    patch '/:id/items/:id', to: 'items#update'
   end
 end

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe 'merchant items edit page' do
+  describe 'as a merchant' do
+    describe 'when i visit the merchant show page of an item' do
+      before :each do
+        @merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        @item_1 = @merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000000)
+        @item_2 = @merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000000)
+      end
+
+      it 'i see a link to update the item information' do
+        visit "/merchants/#{@merchant_1.id}/items/#{@item_1.id}"
+
+        expect(page).to have_link("Update Item Information")
+      end
+
+      it 'when i click the link, i am taken to a page to edit the item' do
+        visit "/merchants/#{@merchant_1.id}/items/#{@item_1.id}"
+
+        click_link "Update Item Information"
+
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{@item_1.id}/edit")
+      end
+
+      it 'and i see a form filled in with the exiting attribute info' do
+        visit "/merchants/#{@merchant_1.id}/items/#{@item_1.id}"
+
+        click_link "Update Item Information"
+
+        expect(page).to have_field("Name", with: "#{@item_1.id}")
+        expect(page).to have_field("Description", with: "#{@item_1.description}")
+        expect(page).to have_field("Unit price", with: "#{@item_1.unit_price}")
+      end
+
+      it 'when i update the info in the form and click submit, i am redirected
+          back to the item show page where i see the updated information and a flash
+          message stating that the info has been successfully updated' do
+        visit "/merchants/#{@merchant_1.id}/items/#{@item_1.id}"
+
+        click_link "Update Item Information"
+
+        fill_in 'Description', with: 'Wine Red Finish, Rosewood Fingerboard'
+        fill_in 'Unit price', with: 200000
+
+        click_button 'Submit'
+
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{@item_1.id}")
+        expect(page).to have_content(@item_1.name)
+        expect(page).to have_content("Description: Wine Red Finish, Rosewood Fingerboard")
+        expect(page).to have_content("Current Selling Price: $200000.00")
+        expect(flash).to match("Information Successfully Updated")
+      end
+    end
+  end
+end

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'merchant items edit page' do
         expect(page).to have_content(@item_1.name)
         expect(page).to have_content("Description: Wine Red Finish, Rosewood Fingerboard")
         expect(page).to have_content("Current Selling Price: $200000.00")
-        expect(page).to have_content(flash[:success])
+        expect(page).to have_content("Information Successfully Updated")
       end
     end
   end

--- a/spec/features/merchants/items/edit_spec.rb
+++ b/spec/features/merchants/items/edit_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'merchant items edit page' do
 
         click_link "Update Item Information"
 
-        expect(page).to have_field("Name", with: "#{@item_1.id}")
+        expect(page).to have_field("Name", with: "#{@item_1.name}")
         expect(page).to have_field("Description", with: "#{@item_1.description}")
         expect(page).to have_field("Unit price", with: "#{@item_1.unit_price}")
       end
@@ -45,15 +45,15 @@ RSpec.describe 'merchant items edit page' do
         click_link "Update Item Information"
 
         fill_in 'Description', with: 'Wine Red Finish, Rosewood Fingerboard'
-        fill_in 'Unit price', with: 200000
+        fill_in 'Unit price', with: 20000000
 
-        click_button 'Submit'
+        click_on 'Save'
 
         expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{@item_1.id}")
         expect(page).to have_content(@item_1.name)
         expect(page).to have_content("Description: Wine Red Finish, Rosewood Fingerboard")
         expect(page).to have_content("Current Selling Price: $200000.00")
-        expect(flash).to match("Information Successfully Updated")
+        expect(page).to have_content(flash[:success])
       end
     end
   end


### PR DESCRIPTION
This branch accomplishes the following:

-creates a link on any given merchant::item show page to another page to edit the item
-creates an edit page for merchant::items, on which there are pre-filled fields with the item's current information, which can be re-written and updated
-generates a flash message telling the user that the information was saved successfully if the item update goes through