### PR TITLE
Merchant item create

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -13,7 +13,13 @@ class Merchants::ItemsController < ApplicationController
 
   def update
     item = Item.find(params[:id])
-    if item.update(item_params)
+    if params[:disable]
+      item.update(status: 1)
+      redirect_to "/merchants/#{item.merchant_id}/items"
+    elsif params[:enable]
+      item.update(status: 0)
+      redirect_to "/merchants/#{item.merchant_id}/items"
+    elsif item.update(item_params)
       redirect_to "/merchants/#{item.merchant_id}/items/#{item.id}"
       flash[:success] = "Information Successfully Updated"
     end

--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -7,6 +7,16 @@ class Merchants::ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def new
+    @merchant = Merchant.find(params[:id])
+  end
+
+  def create
+    merchant = Merchant.find(params[:id])
+    item = merchant.items.create(item_params)
+    redirect_to "/merchants/#{merchant.id}/items"
+  end
+
   def edit
     @item = Item.find(params[:id])
   end

--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -14,10 +14,10 @@ class Merchants::ItemsController < ApplicationController
   def update
     item = Item.find(params[:id])
     if params[:disable]
-      item.update(status: 1)
+      item.update(status: 0)
       redirect_to "/merchants/#{item.merchant_id}/items"
     elsif params[:enable]
-      item.update(status: 0)
+      item.update(status: 1)
       redirect_to "/merchants/#{item.merchant_id}/items"
     elsif item.update(item_params)
       redirect_to "/merchants/#{item.merchant_id}/items/#{item.id}"

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,6 +5,7 @@ class Item < ApplicationRecord
   has_many :transactions, through: :invoices
   has_many :customers, through: :invoices
 
+  enum status: [:enabled, :disabled]
 
   def unit_price_to_currency
     "%.2f" % (unit_price.to_f/100).truncate(2)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,7 +5,7 @@ class Item < ApplicationRecord
   has_many :transactions, through: :invoices
   has_many :customers, through: :invoices
 
-  enum status: [:enabled, :disabled]
+  enum status: [:disabled, :enabled]
 
   def unit_price_to_currency
     "%.2f" % (unit_price.to_f/100).truncate(2)

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -19,3 +19,5 @@
     </div>
   <% end %>
 </div>
+
+<%= link_to "Create New Item", "/merchants/#{@merchant.id}/items/new" %>

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,12 +1,21 @@
-<% @merchant.items.each do |item| %>
-<div id="item-<%= item.id %>">
-  <h3><%= item.name %></h3>
-  <% if item.enabled? %>
-    <%= button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}",
-        params: {disable: true}, method: :patch %>
-  <% else %>
-    <%= button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}",
-        params: {enable: true}, method: :patch %>
+<div id="enabled_items">
+  <h1>Enabled Items</h1>
+  <% @merchant.items.enabled.each do |item| %>
+    <div id="item-<%= item.id %>">
+      <h3><%= item.name %></h3>
+      <%= button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}",
+      params: {disable: true}, method: :patch %>
+    </div>
   <% end %>
 </div>
-<% end %>
+
+<div id="disabled_items">
+  <h1>Disabled Items</h1>
+  <% @merchant.items.disabled.each do |item| %>
+    <div id="item-<%= item.id %>">
+      <h3><%= item.name %></h3>
+      <%= button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}",
+      params: {enable: true}, method: :patch %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,3 +1,12 @@
 <% @merchant.items.each do |item| %>
+<div id="item-<%= item.id %>">
   <h3><%= item.name %></h3>
+  <% if item.enabled? %>
+    <%= button_to "Disable", "/merchants/#{@merchant.id}/items/#{item.id}",
+        params: {disable: true}, method: :patch %>
+  <% else %>
+    <%= button_to "Enable", "/merchants/#{@merchant.id}/items/#{item.id}",
+        params: {enable: true}, method: :patch %>
+  <% end %>
+</div>
 <% end %>

--- a/app/views/merchants/items/new.html.erb
+++ b/app/views/merchants/items/new.html.erb
@@ -1,0 +1,12 @@
+<%= form_with url: "/merchants/#{@merchant.id}/items", method: :post, local: true do |form| %>
+  <%= form.label :name %>
+  <%= form.text_field :name %>
+
+  <%= form.label :description %>
+  <%= form.text_field :description %>
+
+  <%= form.label :unit_price %>
+  <%= form.number_field :unit_price %>
+
+  <%= form.submit "Submit" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,13 +3,15 @@ Rails.application.routes.draw do
   get '/merchants', to: 'merchants#index'
   namespace :merchants do
     get '/:id/items', to: 'items#index'
+    get '/:id/items/new', to: 'items#new'
+    post '/:id/items', to: 'items#create'
     get '/:id/items/:id', to: 'items#show'
     get '/:id/items/:id/edit', to: 'items#edit'
     patch '/:id/items/:id', to: 'items#update'
   end
 
   get '/admin', to: 'admin#index'
-  
+
   namespace :admin do
     get '/merchants', to: 'merchants#index'
     get '/invoices', to: 'invoices#index'

--- a/db/migrate/20220411231505_add_status_column_to_items.rb
+++ b/db/migrate/20220411231505_add_status_column_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusColumnToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_09_154217) do
+ActiveRecord::Schema.define(version: 2022_04_11_231505) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2022_04_09_154217) do
     t.bigint "merchant_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer "status", default: 0
     t.index ["merchant_id"], name: "index_items_on_merchant_id"
   end
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -146,6 +146,44 @@ RSpec.describe 'merchant items index page' do
           expect(page).not_to have_button("Enable")
         end
       end
+
+      it 'i see a link to create a new item, which, when clicked, takes me to
+          a form that allows me to add information, and when i click submit, i
+          am taken back to the index page and i see the new item listed in the
+          disabled section' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000000,
+                                        status: 1)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400000,
+                                        status: 1)
+        item_4 = merchant_1.items.create!(name: "1982 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 600000)
+
+        visit "/merchants/#{merchant_1.id}/items"
+
+        click_link "Create New Item"
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/items/new")
+
+        fill_in "Name", with: "1997 Fender Stratocaster Plus Deluxe"
+        fill_in "Description", with: "Sunburst Finish, Maple Fingerboard"
+        fill_in "Unit price", with: 180000
+        click_button 'Submit'
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/items")
+
+        within("#disabled_items") do
+          expect(page).to have_content("1997 Fender Stratocaster Plus Deluxe")
+        end
+      end
     end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -122,6 +122,10 @@ RSpec.describe 'merchant items index page' do
           within("#item-#{item_4.id}") do
             expect(page).to have_button("Disable")
           end
+
+          expect(page).not_to have_content(item_1.name)
+          expect(page).not_to have_content(item_3.name)
+          expect(page).not_to have_button("Enable")
         end
 
         within("#disabled_items") do
@@ -136,6 +140,10 @@ RSpec.describe 'merchant items index page' do
           within("#item-#{item_3.id}") do
             expect(page).to have_button("Enable")
           end
+
+          expect(page).not_to have_content(item_2.name)
+          expect(page).not_to have_content(item_4.name)
+          expect(page).not_to have_button("Disable")
         end
       end
     end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -91,6 +91,53 @@ RSpec.describe 'merchant items index page' do
           expect(page).to have_button("Disable")
         end
       end
+
+      it 'i see two sections: one for Enabled Items and one for Disabled Items' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000000,
+                                        status: 1)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400000,
+                                        status: 1)
+        item_4 = merchant_1.items.create!(name: "1982 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 600000)
+
+        visit "/merchants/#{merchant_1.id}/items"
+
+        within("#enabled_items") do
+          expect(page).to have_content("Enabled Items")
+          expect(page).to have_content(item_2.name)
+          within("#item-#{item_2.id}") do
+            expect(page).to have_button("Disable")
+          end
+
+          expect(page).to have_content(item_4.name)
+          within("#item-#{item_4.id}") do
+            expect(page).to have_button("Disable")
+          end
+        end
+
+        within("#disabled_items") do
+          expect(page).to have_content("Disabled Items")
+
+          expect(page).to have_content(item_1.name)
+          within("#item-#{item_1.id}") do
+            expect(page).to have_button("Enable")
+          end
+
+          expect(page).to have_content(item_3.name)
+          within("#item-#{item_3.id}") do
+            expect(page).to have_button("Enable")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -22,6 +22,75 @@ RSpec.describe 'merchant items index page' do
         expect(page).to have_content(item_2.name)
         expect(page).not_to have_content(item_3.name)
       end
+
+      it 'next to each item name, i see a button to disable or enable that item' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000000)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400000,
+                                        status: 1)
+
+        visit "/merchants/#{merchant_1.id}/items"
+
+        within("#item-#{item_1.id}") do
+          expect(page).to have_button("Disable")
+        end
+
+        within("#item-#{item_2.id}") do
+          expect(page).to have_button("Disable")
+        end
+
+        within("#item-#{item_3.id}") do
+          expect(page).to have_button("Enable")
+        end
+      end
+
+      it 'when i click the disable/enable button, i am redirected back to the
+          items index and i see that that items status has changed' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000000)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400000,
+                                        status: 1)
+
+        visit "/merchants/#{merchant_1.id}/items"
+
+        within("#item-#{item_1.id}") do
+          click_button("Disable")
+        end
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/items")
+
+        within("#item-#{item_1.id}") do
+          expect(page).to have_button("Enable")
+        end
+
+        within("#item-#{item_2.id}") do
+          expect(page).to have_button("Disable")
+        end
+
+        within("#item-#{item_3.id}") do
+          click_button("Enable")
+        end
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/items")
+
+        within("#item-#{item_3.id}") do
+          expect(page).to have_button("Disable")
+        end
+      end
     end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -39,15 +39,15 @@ RSpec.describe 'merchant items index page' do
         visit "/merchants/#{merchant_1.id}/items"
 
         within("#item-#{item_1.id}") do
-          expect(page).to have_button("Disable")
+          expect(page).to have_button("Enable")
         end
 
         within("#item-#{item_2.id}") do
-          expect(page).to have_button("Disable")
+          expect(page).to have_button("Enable")
         end
 
         within("#item-#{item_3.id}") do
-          expect(page).to have_button("Enable")
+          expect(page).to have_button("Disable")
         end
       end
 
@@ -68,27 +68,27 @@ RSpec.describe 'merchant items index page' do
         visit "/merchants/#{merchant_1.id}/items"
 
         within("#item-#{item_1.id}") do
-          click_button("Disable")
-        end
-
-        expect(current_path).to eq("/merchants/#{merchant_1.id}/items")
-
-        within("#item-#{item_1.id}") do
-          expect(page).to have_button("Enable")
-        end
-
-        within("#item-#{item_2.id}") do
-          expect(page).to have_button("Disable")
-        end
-
-        within("#item-#{item_3.id}") do
           click_button("Enable")
         end
 
         expect(current_path).to eq("/merchants/#{merchant_1.id}/items")
 
-        within("#item-#{item_3.id}") do
+        within("#item-#{item_1.id}") do
           expect(page).to have_button("Disable")
+        end
+
+        within("#item-#{item_2.id}") do
+          expect(page).to have_button("Enable")
+        end
+
+        within("#item-#{item_3.id}") do
+          click_button("Disable")
+        end
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/items")
+
+        within("#item-#{item_3.id}") do
+          expect(page).to have_button("Enable")
         end
       end
 
@@ -111,39 +111,39 @@ RSpec.describe 'merchant items index page' do
 
         visit "/merchants/#{merchant_1.id}/items"
 
-        within("#enabled_items") do
-          expect(page).to have_content("Enabled Items")
+        within("#disabled_items") do
+          expect(page).to have_content("Disabled Items")
           expect(page).to have_content(item_2.name)
           within("#item-#{item_2.id}") do
-            expect(page).to have_button("Disable")
+            expect(page).to have_button("Enable")
           end
 
           expect(page).to have_content(item_4.name)
           within("#item-#{item_4.id}") do
-            expect(page).to have_button("Disable")
+            expect(page).to have_button("Enable")
           end
 
           expect(page).not_to have_content(item_1.name)
           expect(page).not_to have_content(item_3.name)
-          expect(page).not_to have_button("Enable")
+          expect(page).not_to have_button("Disable")
         end
 
-        within("#disabled_items") do
-          expect(page).to have_content("Disabled Items")
+        within("#enabled_items") do
+          expect(page).to have_content("Enabled Items")
 
           expect(page).to have_content(item_1.name)
           within("#item-#{item_1.id}") do
-            expect(page).to have_button("Enable")
+            expect(page).to have_button("Disable")
           end
 
           expect(page).to have_content(item_3.name)
           within("#item-#{item_3.id}") do
-            expect(page).to have_button("Enable")
+            expect(page).to have_button("Disable")
           end
 
           expect(page).not_to have_content(item_2.name)
           expect(page).not_to have_content(item_4.name)
-          expect(page).not_to have_button("Disable")
+          expect(page).not_to have_button("Enable")
         end
       end
     end


### PR DESCRIPTION
This branch accomplishes the following: 

-creates a link on the `merchants::items#index` page, "Create New Item," which takes the user to the `merchants::items#new` page, where the user can input information for a new item
-once the user submits the new item, they are taken back to the `merchants::items#index` page, where they can see their new item listed in the `Disabled Items` section (since new items are created with a default status of `:disabled`