### PR TITLE
Merchant 5 most popular items

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -5,12 +5,18 @@ class Merchant < ApplicationRecord
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
 
+  def items_and_invoice_items
+    items.joins(:invoice_items)
+    .select('items.*, invoice_items.quantity, invoice_items.unit_price')
+    .group('items.id')
+  end
+
   def most_popular_items
-    items.joins(:invoice_items, :invoices, :transactions)
-         .select('items.*, invoice_items.quantity * invoice_items.unit_price AS total_revenue')
-         .distinct
-         .where("transactions.result = 'success'")
-         .order("total_revenue desc")
-         .limit(5)
+    items.joins(:invoices, :transactions)
+    .select('items.*, SUM(invoice_items.quantity * invoice_items.unit_price) AS total_revenue')
+    .where("transactions.result = 'success' AND invoices.status = 1")
+    .group('items.id')
+    .order('total_revenue desc')
+    .limit(5)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -4,4 +4,13 @@ class Merchant < ApplicationRecord
   has_many :invoices, through: :invoice_items
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
+
+  def most_popular_items
+    items.joins(:invoice_items, :invoices, :transactions)
+         .select('items.*, invoice_items.quantity * invoice_items.unit_price AS total_revenue')
+         .distinct
+         .where("transactions.result = 'success'")
+         .order("total_revenue desc")
+         .limit(5)
+  end
 end

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Top 5 Most Popular Items:</h1>
   <% @merchant.most_popular_items.each do |item| %>
   <div id="popular_item-<%= item.id %>">
-    <h3><%= item.name %></h3>
+    <h3><%= link_to "#{item.name}", "/merchants/#{@merchant.id}/items/#{item.id}" %></h3>
     <p>Total Revenue: $<%= "%.2f" % (item.total_revenue.to_f/100).truncate(2) %></p>
   </div>
   <% end %>

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,3 +1,13 @@
+<div id="most_popular_items">
+  <h1>Top 5 Most Popular Items:</h1>
+  <% @merchant.most_popular_items.each do |item| %>
+  <div id="popular_item-<%= item.id %>">
+    <h3><%= item.name %></h3>
+    <p>Total Revenue: $<%= "%.2f" % (item.total_revenue.to_f/100).truncate(2) %></p>
+  </div>
+  <% end %>
+</div>
+
 <div id="enabled_items">
   <h1>Enabled Items</h1>
   <% @merchant.items.enabled.each do |item| %>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -266,6 +266,12 @@ RSpec.describe 'merchant items index page' do
         within "#popular_item-#{item_6.id}" do
           expect(page).to have_content("Total Revenue: $119000.00")
         end
+
+        within "#popular_item-#{item_3.id}" do
+          click_link "#{item_3.name}"
+        end
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/items/#{item_3.id}")
       end
     end
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -222,8 +222,7 @@ RSpec.describe 'merchant items index page' do
         customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
 
         invoice_1 = customer_1.invoices.create!(status: 1)
-        invoice_2 = customer_1.invoices.create!(status: 1)
-        invoice_3 = customer_1.invoices.create!(status: 1)
+        invoice_2 = customer_1.invoices.create!(status: 0)
         invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: item_1.unit_price, status: 0)
         invoice_item_2 = InvoiceItem.create!(item: item_9, invoice: invoice_1, quantity: 25, unit_price: item_9.unit_price, status: 0)
         invoice_item_3 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 1, unit_price: item_2.unit_price, status: 0)
@@ -231,15 +230,13 @@ RSpec.describe 'merchant items index page' do
         invoice_item_5 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 35, unit_price: item_3.unit_price, status: 0)
         invoice_item_6 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 10, unit_price: item_5.unit_price, status: 0)
         invoice_item_7 = InvoiceItem.create!(item: item_6, invoice: invoice_1, quantity: 17, unit_price: item_6.unit_price, status: 0)
-        invoice_item_8 = InvoiceItem.create!(item: item_8, invoice: invoice_1, quantity: 22, unit_price: item_8.unit_price, status: 0)
+        invoice_item_8 = InvoiceItem.create!(item: item_8, invoice: invoice_1, quantity: 10000, unit_price: item_8.unit_price, status: 0)
         invoice_item_9 = InvoiceItem.create!(item: item_7, invoice: invoice_1, quantity: 1, unit_price: item_7.unit_price, status: 0)
         invoice_item_10 = InvoiceItem.create!(item: item_10, invoice: invoice_1, quantity: 4, unit_price: item_10.unit_price, status: 0)
         invoice_item_11 = InvoiceItem.create!(item: item_5, invoice: invoice_2, quantity: 10000, unit_price: item_5.unit_price, status: 0)
         invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: item_7.unit_price, status: 0)
-        invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_3, quantity: 10000, unit_price: item_8.unit_price, status: 0)
         transaction_1 = invoice_1.transactions.create!(credit_card_number: 0000111122223333, result: "success")
-        transaction_1 = invoice_2.transactions.create!(credit_card_number: 0000111122223333, result: "failed")
-        transaction_2 = invoice_3.transactions.create!(credit_card_number: 0000111122223333, result: "success")
+        transaction_2 = invoice_2.transactions.create!(credit_card_number: 0000111122223333, result: "failed")
 
         visit "/merchants/#{merchant_1.id}/items"
 
@@ -251,7 +248,7 @@ RSpec.describe 'merchant items index page' do
         end
 
         within "#popular_item-#{item_8.id}" do
-          expect(page).to have_content("Total Revenue: $1022000.00")
+          expect(page).to have_content("Total Revenue: $10000000.00")
         end
 
         within "#popular_item-#{item_1.id}" do
@@ -266,7 +263,7 @@ RSpec.describe 'merchant items index page' do
           expect(page).to have_content("Total Revenue: $140000.00")
         end
 
-        within "#popular_item-#{item_8.id}" do
+        within "#popular_item-#{item_6.id}" do
           expect(page).to have_content("Total Revenue: $119000.00")
         end
       end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -184,6 +184,92 @@ RSpec.describe 'merchant items index page' do
           expect(page).to have_content("1997 Fender Stratocaster Plus Deluxe")
         end
       end
+
+      it 'i see the names of the top 5 most popular items by total revenue,
+          which are also links to those items show pages, and i see those
+          items total revenue generated' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000000)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400000)
+        item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 600000)
+        item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 900000)
+        item_6 = merchant_1.items.create!(name: "1993 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 700000)
+        item_7 = merchant_1.items.create!(name: "2004 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 200000)
+        item_8 = merchant_1.items.create!(name: "1997 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 100000)
+        item_9 = merchant_1.items.create!(name: "1996 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 100000)
+        item_10 = merchant_1.items.create!(name: "1975 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 400000)
+        customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
+
+        invoice_1 = customer_1.invoices.create!(status: 1)
+        invoice_2 = customer_1.invoices.create!(status: 1)
+        invoice_3 = customer_1.invoices.create!(status: 1)
+        invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: item_1.unit_price, status: 0)
+        invoice_item_2 = InvoiceItem.create!(item: item_9, invoice: invoice_1, quantity: 25, unit_price: item_9.unit_price, status: 0)
+        invoice_item_3 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 1, unit_price: item_2.unit_price, status: 0)
+        invoice_item_4 = InvoiceItem.create!(item: item_4, invoice: invoice_1, quantity: 31, unit_price: item_4.unit_price, status: 0)
+        invoice_item_5 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 35, unit_price: item_3.unit_price, status: 0)
+        invoice_item_6 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 10, unit_price: item_5.unit_price, status: 0)
+        invoice_item_7 = InvoiceItem.create!(item: item_6, invoice: invoice_1, quantity: 17, unit_price: item_6.unit_price, status: 0)
+        invoice_item_8 = InvoiceItem.create!(item: item_8, invoice: invoice_1, quantity: 22, unit_price: item_8.unit_price, status: 0)
+        invoice_item_9 = InvoiceItem.create!(item: item_7, invoice: invoice_1, quantity: 1, unit_price: item_7.unit_price, status: 0)
+        invoice_item_10 = InvoiceItem.create!(item: item_10, invoice: invoice_1, quantity: 4, unit_price: item_10.unit_price, status: 0)
+        invoice_item_11 = InvoiceItem.create!(item: item_5, invoice: invoice_2, quantity: 10000, unit_price: item_5.unit_price, status: 0)
+        invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: item_7.unit_price, status: 0)
+        invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_3, quantity: 10000, unit_price: item_8.unit_price, status: 0)
+        transaction_1 = invoice_1.transactions.create!(credit_card_number: 0000111122223333, result: "success")
+        transaction_1 = invoice_2.transactions.create!(credit_card_number: 0000111122223333, result: "failed")
+        transaction_2 = invoice_3.transactions.create!(credit_card_number: 0000111122223333, result: "success")
+
+        visit "/merchants/#{merchant_1.id}/items"
+
+        within "#most_popular_items" do
+          expect(item_8.name).to appear_before(item_1.name)
+          expect(item_1.name).to appear_before(item_4.name)
+          expect(item_4.name).to appear_before(item_3.name)
+          expect(item_3.name).to appear_before(item_6.name)
+        end
+
+        within "#popular_item-#{item_8.id}" do
+          expect(page).to have_content("Total Revenue: $1022000.00")
+        end
+
+        within "#popular_item-#{item_1.id}" do
+          expect(page).to have_content("Total Revenue: $250000.00")
+        end
+
+        within "#popular_item-#{item_4.id}" do
+          expect(page).to have_content("Total Revenue: $186000.00")
+        end
+
+        within "#popular_item-#{item_3.id}" do
+          expect(page).to have_content("Total Revenue: $140000.00")
+        end
+
+        within "#popular_item-#{item_8.id}" do
+          expect(page).to have_content("Total Revenue: $119000.00")
+        end
+      end
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Merchant, type: :model do
                                         unit_price: 40)
         customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
         invoice_1 = customer_1.invoices.create!(status: 1)
-        invoice_2 = customer_1.invoices.create!(status: 1)
+        invoice_2 = customer_1.invoices.create!(status: 0)
         invoice_3 = customer_1.invoices.create!(status: 1)
         invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: item_1.unit_price, status: 0)
         invoice_item_2 = InvoiceItem.create!(item: item_9, invoice: invoice_1, quantity: 25, unit_price: item_9.unit_price, status: 0)
@@ -62,8 +62,8 @@ RSpec.describe Merchant, type: :model do
         invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: item_7.unit_price, status: 0)
         invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_3, quantity: 10000, unit_price: item_8.unit_price, status: 0)
         transaction_1 = invoice_1.transactions.create!(credit_card_number: 0000111122223333, result: "success")
-        transaction_1 = invoice_2.transactions.create!(credit_card_number: 0000111122223333, result: "failed")
-        transaction_2 = invoice_3.transactions.create!(credit_card_number: 0000111122223333, result: "success")
+        transaction_2 = invoice_2.transactions.create!(credit_card_number: 0000111122223333, result: "failed")
+        transaction_3 = invoice_3.transactions.create!(credit_card_number: 0000111122223333, result: "success")
 
         expect(merchant_1.most_popular_items).to eq([item_8, item_1, item_4, item_3, item_6])
       end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -8,4 +8,65 @@ RSpec.describe Merchant, type: :model do
     it { should have_many(:customers).through(:invoices)}
     it { should have_many(:transactions).through(:invoices)}
   end
+
+  describe 'instance methods' do
+    describe '.most_popular_items' do
+      it 'should return the 5 most popular items for some merchant in terms of
+          total revenue generated' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000000)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400000)
+        item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 600000)
+        item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 900000)
+        item_6 = merchant_1.items.create!(name: "1993 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 700000)
+        item_7 = merchant_1.items.create!(name: "2004 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 200000)
+        item_8 = merchant_1.items.create!(name: "1997 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 100000)
+        item_9 = merchant_1.items.create!(name: "1996 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 100000)
+        item_10 = merchant_1.items.create!(name: "1975 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 400000)
+        customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
+        invoice_1 = customer_1.invoices.create!(status: 1)
+        invoice_2 = customer_1.invoices.create!(status: 1)
+        invoice_3 = customer_1.invoices.create!(status: 1)
+        invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: item_1.unit_price, status: 0)
+        invoice_item_2 = InvoiceItem.create!(item: item_9, invoice: invoice_1, quantity: 25, unit_price: item_9.unit_price, status: 0)
+        invoice_item_3 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 1, unit_price: item_2.unit_price, status: 0)
+        invoice_item_4 = InvoiceItem.create!(item: item_4, invoice: invoice_1, quantity: 31, unit_price: item_4.unit_price, status: 0)
+        invoice_item_5 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 35, unit_price: item_3.unit_price, status: 0)
+        invoice_item_6 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 10, unit_price: item_5.unit_price, status: 0)
+        invoice_item_7 = InvoiceItem.create!(item: item_6, invoice: invoice_1, quantity: 17, unit_price: item_6.unit_price, status: 0)
+        invoice_item_8 = InvoiceItem.create!(item: item_8, invoice: invoice_1, quantity: 22, unit_price: item_8.unit_price, status: 0)
+        invoice_item_9 = InvoiceItem.create!(item: item_7, invoice: invoice_1, quantity: 1, unit_price: item_7.unit_price, status: 0)
+        invoice_item_10 = InvoiceItem.create!(item: item_10, invoice: invoice_1, quantity: 4, unit_price: item_10.unit_price, status: 0)
+        invoice_item_11 = InvoiceItem.create!(item: item_5, invoice: invoice_2, quantity: 10000, unit_price: item_5.unit_price, status: 0)
+        invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: item_7.unit_price, status: 0)
+        invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_3, quantity: 10000, unit_price: item_8.unit_price, status: 0)
+        transaction_1 = invoice_1.transactions.create!(credit_card_number: 0000111122223333, result: "success")
+        transaction_1 = invoice_2.transactions.create!(credit_card_number: 0000111122223333, result: "failed")
+        transaction_2 = invoice_3.transactions.create!(credit_card_number: 0000111122223333, result: "success")
+
+        expect(merchant_1.most_popular_items).to eq([item_8, item_1, item_4, item_3, item_6])
+      end
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -16,34 +16,34 @@ RSpec.describe Merchant, type: :model do
         merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
         item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
                                         description: "Tobacco Burst Finish, Rosewood Fingerboard",
-                                        unit_price: 25000000)
+                                        unit_price: 2500)
         item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
                                         description: "Seafoam Green Finish, Maple Fingerboard",
-                                        unit_price: 10000000)
+                                        unit_price: 1000)
         item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
                                         description: "Cherry Red Finish, Rosewood Fingerboard",
-                                        unit_price: 400000)
+                                        unit_price: 40)
         item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
                                         description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 600000)
+                                        unit_price: 60)
         item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
                                         description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 900000)
+                                        unit_price: 90)
         item_6 = merchant_1.items.create!(name: "1993 Gibson Les Paul",
                                         description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 700000)
+                                        unit_price: 70)
         item_7 = merchant_1.items.create!(name: "2004 Gibson Les Paul",
                                         description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 200000)
+                                        unit_price: 20)
         item_8 = merchant_1.items.create!(name: "1997 Gibson Les Paul",
                                         description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 100000)
+                                        unit_price: 10)
         item_9 = merchant_1.items.create!(name: "1996 Gibson Les Paul",
                                         description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 100000)
+                                        unit_price: 10)
         item_10 = merchant_1.items.create!(name: "1975 Gibson Les Paul",
                                         description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 400000)
+                                        unit_price: 40)
         customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
         invoice_1 = customer_1.invoices.create!(status: 1)
         invoice_2 = customer_1.invoices.create!(status: 1)


### PR DESCRIPTION
This branch accomplishes the following: 

-creates the `most_popular_items` instance method for the `merchant` model, which returns its 5 most popular items in terms of their total generated revenue, which is also returned as a new attribute
-creates a `Top 5 Most Popular Items` section on the `merchants::index#index` page, which displays a given merchant's `most_popular_items` along with their total revenue and with their names as links to their respective `merchants::items#show` pages