### PR TITLE
Refactor: update tests to prevent deprecation errors when running tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,10 +175,10 @@ GEM
     rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-rails (5.1.1)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
+    rspec-rails (4.0.2)
+      actionpack (>= 4.2)
+      activesupport (>= 4.2)
+      railties (>= 4.2)
       rspec-core (~> 3.10)
       rspec-expectations (~> 3.10)
       rspec-mocks (~> 3.10)
@@ -262,7 +262,7 @@ DEPENDENCIES
   pry
   puma (~> 3.11)
   rails (~> 5.2.6)
-  rspec-rails
+  rspec-rails (~> 4.0.1)
   sass-rails (~> 5.0)
   shoulda-matchers
   simplecov

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Admin Dashboard" do
     expect(page).to have_no_content(invoice_3.id)
     expect(page).to have_no_content(invoice_5.id)
 
-    click_link invoice_1.id
+    click_link "#{invoice_1.id}"
     expect(current_path).to eq("/admin/invoices/#{invoice_1.id}")
   end
 

--- a/spec/features/admin/invoices/index_spec.rb
+++ b/spec/features/admin/invoices/index_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Admin Invoices Index" do
     expect(page).to have_content("#{invoice_3.id}")
     expect(page).to have_content("#{invoice_4.id}")
     expect(page).to have_content("#{invoice_5.id}")
-    click_link(invoice_1.id)
+    click_link("#{invoice_1.id}")
 
     expect(current_path).to eq("/admin/invoices/#{invoice_1.id}")
   end

--- a/spec/features/merchants/dashboard_spec.rb
+++ b/spec/features/merchants/dashboard_spec.rb
@@ -242,9 +242,21 @@ RSpec.describe 'merchant dashboard page' do
 
 
       visit "/merchants/#{merchant.id}/dashboard"
-      find("ol#ready_to_ship li:nth-child(1)").should have_content("Grenade")
-      find("ol#ready_to_ship li:nth-child(2)").should have_content("Beyblade")
-      find("ol#ready_to_ship li:nth-child(3)").should have_content("Butter")
-      find("ol#ready_to_ship li:nth-child(4)").should have_content("Toast")
+
+      within "#ready_to_ship li:nth-child(1)" do
+        expect(page).to have_content("Grenade")
+      end
+
+      within "#ready_to_ship li:nth-child(2)" do
+        expect(page).to have_content("Beyblade")
+      end
+
+      within "#ready_to_ship li:nth-child(3)" do
+        expect(page).to have_content("Butter")
+      end
+
+      within "#ready_to_ship li:nth-child(4)" do
+        expect(page).to have_content("Toast")
+      end
   end
 end

--- a/spec/features/merchants/invoices/index_spec.rb
+++ b/spec/features/merchants/invoices/index_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe 'merchant invoices index page' do
         visit "/merchants/#{merchant_1.id}/invoices"
 
         expect(page).to have_content(invoice_1.status)
-        expect(page).to have_link(invoice_1.id)
+        expect(page).to have_link("#{invoice_1.id}")
         expect(page).to have_content(invoice_2.status)
-        expect(page).to have_link(invoice_2.id)
-        
-        expect(page).not_to have_link(invoice_3.id)
+        expect(page).to have_link("#{invoice_2.id}")
+
+        expect(page).not_to have_link("#{invoice_3.id}")
 
         within "#invoice-#{invoice_2.id}" do
           click_link "#{invoice_2.id}"


### PR DESCRIPTION
This branch updates some formatting in the test files to prevent some deprecation errors that we were receiving in the terminal.