### PR TITLE
Merchant invoice update item status

### DIFF
--- a/app/controllers/invoice_items_controller.rb
+++ b/app/controllers/invoice_items_controller.rb
@@ -1,0 +1,7 @@
+class InvoiceItemsController < ApplicationController
+  def update
+    invoice_item = InvoiceItem.find(params[:id])
+    invoice_item.update(status: params[:status])
+    redirect_to "/merchants/#{params[:merchant_id]}/invoices/#{invoice_item.invoice_id}"
+  end
+end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -4,7 +4,8 @@ class InvoicesController < ApplicationController
   end
 
   def show
+    @merchant = Merchant.find(params[:merchant_id])
     @invoice = Invoice.find(params[:id])
-    @items = Item.items_by_merchant(params[:merchant_id])
+    @items = @merchant.items
   end
 end

--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -7,12 +7,18 @@ Created At: <%= @invoice.dates %>
 Customer Name: <%= @invoice.full_name %>
 <br>
 <% @invoice.invoice_items.each do |invoice_item|%>
-  <% if invoice_item.belongs_to_merchant(params[:merchant_id]) %>
-    <h3>Invoice Item <%= invoice_item.id%></h3>
+<div id="item-<%= invoice_item.id %>">
+  <% if invoice_item.belongs_to_merchant(@merchant.id) %>
+    <h3>Invoice Item <%= invoice_item.id %></h3>
     Quantity: <%=invoice_item.quantity %>
     <br>
     Unit Price: <%=invoice_item.unit_price%>
     <br>
-    Status: <%=invoice_item.status%>
+    <%= form_with url: "/merchants/#{@merchant.id}/invoice_items/#{invoice_item.id}", method: :patch, local: true do |form| %>
+      <%= form.label "Status" %>
+      <%= form.select(:status, options_for_select([['Pending', :pending], ['Packaged', :packaged], ['Shipped', :shipped]], invoice_item.status)) %>
+      <%= form.submit "Update Item Status" %>
+    <% end %>
   <% end %>
+</div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :merchants do
     resources :items
     resources :invoices
+    resources :invoice_items
   end
 
   get '/merchants/:id/dashboard', to: 'merchants#show'

--- a/spec/features/merchants/invoice/show_spec.rb
+++ b/spec/features/merchants/invoice/show_spec.rb
@@ -50,4 +50,73 @@ RSpec.describe 'the merchant invoice show page' do
         expect(page).to_not have_content("Dave")
         expect(page).to_not have_content("Fogherty")
   end
+
+  describe 'as a merchant' do
+    describe 'when i visit my merchant invoice show page' do
+      before :each do
+        @merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        @item_1 = @merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000000)
+        @item_2 = @merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000000)
+        @item_3 = @merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400000,
+                                        status: 1)
+        @customer = Customer.create!(first_name: "Steven", last_name: "Seagal")
+        @invoice_1 = @customer.invoices.create!(status: 1)
+        @invoice_2 = @customer.invoices.create!(status: 0)
+        @invoice_item_1 = @item_1.invoice_items.create!(invoice_id: @invoice_1.id, quantity:45, unit_price: 1000, status: 0)
+        @invoice_item_2 = @item_2.invoice_items.create!(invoice_id: @invoice_1.id, quantity:222, unit_price: 1000, status: 2)
+        @invoice_item_3 = @item_2.invoice_items.create!(invoice_id: @invoice_2.id, quantity:222, unit_price: 1000, status: 1)
+        @invoice_item_4 = @item_3.invoice_items.create!(invoice_id: @invoice_1.id, quantity:222, unit_price: 1000, status: 1)
+
+        visit "/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}"
+      end
+
+      it "i see that each invoice item status is a select field
+          and i see that the invoice item's current status is selected" do
+
+        within "#invoice_item-#{@invoice_item_1.id}" do
+          expect(page).to have_select(:status, selected: 'Pending')
+        end
+
+        within "#invoice_item-#{@invoice_item_2.id}" do
+          expect(page).to have_select(:status, selected: 'Shipped')
+        end
+
+        within "#invoice_item-#{@invoice_item_3.id}" do
+          expect(page).to have_select(:status, selected: 'Packaged')
+        end
+      end
+
+      it "when i click the select field, then i can select a new status
+          for the item, and next to the select field i see a button to
+          update item status, which, when clicked, takes me back to the
+          merchant invoice show page and i see that my item's status
+          has been updated" do
+
+        within "#invoice_item-#{@invoice_item_3.id}" do
+          select 'Shipped', :from => :status
+          click_button("Update Invoice Status")
+        end
+
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}")
+
+        within "#invoice_item-#{@invoice_item_3.id}" do
+          expect(page).to have_select(:status, selected: 'Shipped')
+        end
+
+        within "#invoice_item-#{@invoice_item_1.id}" do
+          expect(page).to have_select(:status, selected: 'Pending')
+        end
+
+        within "#invoice_item-#{@invoice_item_2.id}" do
+          expect(page).to have_select(:status, selected: 'Shipped')
+        end
+      end
+    end
+  end
 end

--- a/spec/features/merchants/invoice/show_spec.rb
+++ b/spec/features/merchants/invoice/show_spec.rb
@@ -79,15 +79,15 @@ RSpec.describe 'the merchant invoice show page' do
       it "i see that each invoice item status is a select field
           and i see that the invoice item's current status is selected" do
 
-        within "#invoice_item-#{@invoice_item_1.id}" do
+        within "#item-#{@invoice_item_1.id}" do
           expect(page).to have_select(:status, selected: 'Pending')
         end
 
-        within "#invoice_item-#{@invoice_item_2.id}" do
+        within "#item-#{@invoice_item_2.id}" do
           expect(page).to have_select(:status, selected: 'Shipped')
         end
 
-        within "#invoice_item-#{@invoice_item_3.id}" do
+        within "#item-#{@invoice_item_4.id}" do
           expect(page).to have_select(:status, selected: 'Packaged')
         end
       end
@@ -97,23 +97,23 @@ RSpec.describe 'the merchant invoice show page' do
           update item status, which, when clicked, takes me back to the
           merchant invoice show page and i see that my item's status
           has been updated" do
-
-        within "#invoice_item-#{@invoice_item_3.id}" do
+        
+        within "#item-#{@invoice_item_4.id}" do
           select 'Shipped', :from => :status
-          click_button("Update Invoice Status")
+          click_button("Update Item Status")
         end
 
         expect(current_path).to eq("/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}")
 
-        within "#invoice_item-#{@invoice_item_3.id}" do
+        within "#item-#{@invoice_item_4.id}" do
           expect(page).to have_select(:status, selected: 'Shipped')
         end
 
-        within "#invoice_item-#{@invoice_item_1.id}" do
+        within "#item-#{@invoice_item_1.id}" do
           expect(page).to have_select(:status, selected: 'Pending')
         end
 
-        within "#invoice_item-#{@invoice_item_2.id}" do
+        within "#item-#{@invoice_item_2.id}" do
           expect(page).to have_select(:status, selected: 'Shipped')
         end
       end


### PR DESCRIPTION
This branch accomplishes the following: 

-adds a select field to each `invoice_item` listed on the `merchants::invoices#show` page listing its current status, and in which the user can select a new status that can be updated by clicking the `Update Item Status` button next to it

-this updates the `invoice_item` status and redirects the user back to the same `merchants::invoices#show` page where the new status is now displayed in the select field

-refactors the `merchants::invoices#show` page to refer to `@merchant` passed from the controller instead of calling `params[:merchant_id]` in the view